### PR TITLE
Add Compatible Magazines Retrieval and Parse to SQL tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ texHeaders.bin
 
 # SQM
 *.sqm
+
+# Tools temporary files
+tools/temp

--- a/tools/compatibleMagazinesRetrieve.sqf
+++ b/tools/compatibleMagazinesRetrieve.sqf
@@ -1,0 +1,29 @@
+_weapons = []; // [weap1, weap2, weap3]
+_magazines = []; // [ [weap1mag1, weap1mag2, weap1mag3], [weap2mag1, weap2mag2, weap2mag3] ]
+_combined = []; // [ [weapon, magazine1], [weapon, magazine2] ]
+
+_config = configFile >> "CfgWeapons";
+
+for "_i" from 0 to (count _config - 1) do {
+    _configWeapon = _config select _i;
+    _configMagazines = _configWeapon >> "magazines"; // Exclude weapons without compatible magazines config entry
+    _linkedItems = _configWeapon >> "LinkedItems"; // Exclude linked items (weapons with preset attachments)
+
+    if (isArray _configMagazines && !(isClass _linkedItems)) then {
+        _compatibleMagazines = if ((getArray _configMagazines) isEqualTo []) then {false} else {true}; // Exclude weapons with no compatible magazines
+        _weaponScope = if ((getNumber (_configWeapon >> "scope")) == 2) then {true} else {false}; // Only scope 2 (public) weapons
+        _weaponType = if ((getNumber (_configWeapon >> "type")) in [1, 2, 4, 2^12]) then {true} else {false}; // Only primary (1), handguns (2), secondaries (4) and binoculars (4096)
+
+        if (_compatibleMagazines && _weaponScope && _weaponType) then {
+            _weapons pushBack (configName _configWeapon);
+            _magazines pushBack (getArray _configMagazines);
+            _combined pushBack (configName _configWeapon);
+            _combined pushBack (getArray _configMagazines)
+        };
+    };
+};
+
+_br = toString [13, 10]; // CRLF
+_compatibleMagazinesString = [_weapons, _magazines] joinString _br;
+//copyToClipboard _compatibleMagazinesString;
+copyToClipboard str(_combined);

--- a/tools/compatibleMagazinesToSQL.py
+++ b/tools/compatibleMagazinesToSQL.py
@@ -15,13 +15,11 @@ OUTPUT = "temp\\compatibleMagazines_OUPUT.txt"
 SQL_DBTABLE = "apollo.ammotypes"
 ##########################
 
-
 def writeToFile(weapon, magazines):
     # Write SQL statements to output file
     with open(OUTPUT, "a") as file:
         for magazine in magazines:
             file.write("INSERT INTO {} (weaponClass, ammoClass) VALUES ('{}', '{}');\n".format(SQL_DBTABLE, weapon, magazine))
-
 
 def main():
     # Check for input file

--- a/tools/compatibleMagazinesToSQL.py
+++ b/tools/compatibleMagazinesToSQL.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+###############################
+# Parses Arma 3 output of     #
+# weapons with compatible     #
+# magazines to SQL statements #
+###############################
+
+######## GLOBALS #########
+INPUT = "temp\\compatibleMagazines_INPUT.txt"
+OUTPUT = "temp\\compatibleMagazines_OUPUT.txt"
+SQL_DBTABLE = "apollo.ammotypes"
+##########################
+
+
+def writeToFile(weapon, magazines):
+    # Write SQL statements to output file
+    with open(OUTPUT, "a") as file:
+        for magazine in magazines:
+            file.write("INSERT INTO {} (weaponClass, ammoClass) VALUES ('{}', '{}');\n".format(SQL_DBTABLE, weapon, magazine))
+
+
+def main():
+    # Check for input file
+    if not os.path.isfile(INPUT):
+        print("Input file missing!\n\nYou must first run compatibleMagazinesRetrieve.sqf in Arma 3, then paste the clipboard to file {}.".format(INPUT))
+        sys.exit(0)
+
+    # Prepare output file (clean and add SQL truncate statement)
+    if not os.path.exists("temp"):
+        os.makedirs("temp")
+
+    with open(OUTPUT, "w") as file:
+        print("Preparing output file ...\n")
+        file.write("TRUNCATE TABLE {};\n\n".format(SQL_DBTABLE))
+
+    # Read input file
+    with open(INPUT, "r") as file:
+        feed = file.read()
+        # Replace characters and form a list
+        content = feed.replace(" ", "")[1:-2].replace('"', "").replace("],", "]],").split("],")
+
+        # Counters
+        countWeapons = 0
+        countMagazines = 0
+
+        print("Adding SQL insert statements ...")
+        for item in content:
+            # Replace characters and forms a list
+            item = item.replace("[", "").replace("]", "").split(",")
+
+            # Select items, write and print
+            weapon = item[0]
+            magazines = item[1:]
+            writeToFile(weapon, magazines)
+
+            # Increase counters
+            countWeapons += 1
+            countMagazines += len(magazines)
+
+    print("- {} Weapons Added".format(countWeapons))
+    print("- {} Magazines Added".format(countMagazines))
+
+    print("\nSQL script written to file {}, paste the contents into MySQL Workbench and run it.".format(OUTPUT))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Semi-automatic retrieval and parsing of compatible weapon magazines, used as a helper tool for Armory Ammo Assistant.

Workflow:
- Run `exec VM "compatibleMagazinesRetrieve.sqf"` in Arma 3 debug console, information will get copied to a clipboard (so far we haven't exceeded the limit yet, once we do we can switch over to ACE3's clipboard extension)
- Paste contents into a file `compatibleMagazines_INPUT.txt` inside `temp` folder which is next to the Python script `compatibleMagazinesToSQL.py`
- Run Python script in Command Line with `python3 compatibleMagazinesToSQL.py`, this will create SQL statements in a file `compatibleMagazines_OUPUT.txt` in the same `temp` folder
- Copy contents of `compatibleMagazines_OUPUT.txt` into whatever MySQL script runner you use (eg. MySQL Workbench) and run it
- Table will get truncated and new information will be added to it