### PR TITLE
Add Base Spectator and TAC Scripts mission plug-in structure

### DIFF
--- a/scripts/CfgFunctions.hpp
+++ b/scripts/CfgFunctions.hpp
@@ -1,0 +1,10 @@
+class CfgFunctions {
+    class TAC_Scripts {
+        tag = "TAC_Scripts";
+        class functions {
+            file = "functions";
+            //recompile = 1; // Debug - Requires allowFunctionsRecompile = 1; in description.ext
+            class baseSpectator;
+        };
+    };
+};

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,14 @@
+# TAC Scripts
+
+Various staging for proper framework, proof of concept and other scripts for plug into missions.
+
+### Usage
+
+- Copy `CfgFunctions.hpp` and `functions` folder to your mission root (next to `description.ext`)
+- Add `#include "CfgFunctions.hpp"` to `description.ext`
+- Remove unneeded functions from `functions` folder and their respective classes from `CfgFunctions.hpp` (eg. `class someFunction;`)
+
+#### Debugging
+
+- Add `allowFunctionsRecompile = 1;` to `description.ext`
+- Uncomment `recompile = 1;` in `CfgFunctions.hpp`

--- a/scripts/fnc_baseSpectator.sqf
+++ b/scripts/fnc_baseSpectator.sqf
@@ -1,0 +1,74 @@
+/*
+    Call from initPlayerLocal.sqf through CfgFunctions or compile directly:
+        params ["_player"];
+        [_player] call compile preprocessFileLineNumbers "functions\fnc_baseSpectator.sqf";
+
+    Define SPECATOR_OBJECT defined below this comment.
+*/
+#define SPECTATOR_OBJECT baseSpectator // Object where spectator is toggled on
+
+params ["_player"];
+
+// Event for closing spectator from other machines
+["tac_baseSpectatorOff", {
+    if (_thisArgs getVariable ["tac_baseSpectatorSet", false]) then {
+        [false] call ace_spectator_fnc_setSpectator;
+        _thisArgs setVariable ["tac_baseSpectatorSet", false];
+    };
+}, _player] call CBA_fnc_addEventHandlerArgs;
+
+// Player open spectator on specified object
+private _actionOpenSpectator = [
+    "tac_baseSpectatorOpen",
+    "Open Spectator",
+    "\A3\UI_F_Curator\Data\Displays\RscDisplayCurator\modeUnits_ca.paa",
+    {
+        [true] call ace_spectator_fnc_setSpectator;
+        (_this select 2) setVariable ["tac_baseSpectatorSet", true];
+    },
+    {
+        SPECTATOR_OBJECT getVariable ["tac_baseSpectatorEnabled", false]
+    },
+    {},
+    _player
+] call ace_interact_menu_fnc_createAction;
+
+[SPECTATOR_OBJECT, 0, ["ACE_MainActions"], _actionOpenSpectator] call ace_interact_menu_fnc_addActionToObject;
+
+// Admin chat command to toggle spectator availability
+["tac-spectator", {
+    params ["_args"];
+    if (_args == "on") then {
+        SPECTATOR_OBJECT setVariable ["tac_baseSpectatorEnabled", true, true];
+    } else {
+        SPECTATOR_OBJECT setVariable ["tac_baseSpectatorEnabled", false, true];
+        ["tac_baseSpectatorOff", nil, call CBA_fnc_players] call CBA_fnc_targetEvent;
+    };
+}] call CBA_fnc_registerChatCommand;
+
+// Player chat command to exit spectator
+["tac-spectator-exit", {
+    [false] call ace_spectator_fnc_setSpectator;
+    ace_player setVariable ["tac_baseSpectatorSet", false];
+}, "all"] call cba_fnc_registerChatCommand;
+
+
+// Can't add ACE canInteractWith exception in SQF
+/*
+private _actionCloseSpectator = [
+    "tac_baseSpectatorClose",
+    "Close Spectator",
+    "\A3\UI_F_Curator\Data\Displays\RscDisplayCurator\modeUnits_ca.paa",
+    {
+        //TODO stage, set?
+        [false] call ace_spectator_fnc_setSpectator;
+    },
+    {
+        (_this select 2) getVariable ["tac_baseSpectatorSet", false];
+    },
+    {},
+    _player
+] call ace_interact_menu_fnc_createAction;
+
+[_player, 1, ["ACE_SelfActions"], _actionCloseSpectator] call ace_interact_menu_fnc_addActionToObject;
+*/


### PR DESCRIPTION
- Add `TAC_Scripts` functions namespace for proof of concept, staging for proper framework and other scripts
- Add Base Spectator script allowing admin to enable dynamic spectator availability on an object